### PR TITLE
whatsnew_0233.txt corrections

### DIFF
--- a/whatsnew/whatsnew_0233.txt
+++ b/whatsnew/whatsnew_0233.txt
@@ -481,7 +481,7 @@ Merged pull requests
 - 8016: machine/rtc65271.cpp, firebeat.cpp: Allow NVRAM to be initialized with default data from memory region. [Windy Fairy]
 - 8034: bus/centronics: Added +5 V peripheral sense input signal (used by Epson QX-10). [Brian Johnson]
 - 8044: ksys573.cpp: Changed CD-ROM cycles per sector from 5,000 to 30,000 (fixes errors in Drummania 2nd Mix). [Windy Fairy]
-- 8073: nes.xml: Added eleven entries, replaced several entries with verified dumps, and corrected metadata. [quasiscroto]
+- 8073: nes.xml: Added eleven entries, replaced several entries with verified dumps, and corrected metadata. [0kmg]
 - 8096: video/namcos2_sprite.cpp: Corrected tile/size selection for Final Lap sprites. [David Haywood]
 - 8098: bus/coco/coco_ssc.cpp: Improved reset handling. [Tim Lindner]
 - 8099: machine/coco.cpp: Fixed joystick port device selection (MT07475). [Tim Lindner]
@@ -489,14 +489,14 @@ Merged pull requests
 - 8102: alg.cpp: Fixed “Picmatic” company name. [ClawGrip]
 - 8103: phoenix.cpp: Corrected manufacturer for “G.G.I. Corporation” bootlegs. [ClawGrip]
 - 8104: bus/coco: Added CoCo Max HI-RES input module; machine/6883sam.cpp: fixed address mask in ROM/RAM mode. [Tim Lindner]
-- 8105: gamegear.xml, sms.xml: Added three prototypes. [smspower, quasiscroto]
+- 8105: gamegear.xml, sms.xml: Added three prototypes. [smspower, 0kmg]
 - 8108: spinb.cpp: Added Bushido (set 3). [Victor Fernandez (City Game), ClawGrip]
-- 8110: nes.xml: Added several entries, and corrected metadata. [Hidden Palace, No-Intro, Skrybe, Stephan Reese, quasiscroto]
+- 8110: nes.xml: Added several entries, and corrected metadata. [Hidden Palace, No-Intro, Skrybe, Stephan Reese, 0kmg]
 - 8111: rohga.cpp: Added Nitro Ball (World, set 3). [JammaFever, Nebula, Recreativos Piscis, Sergio Galiano]
-- 8112: a800.xml: Removed spurious C1 control characters. [quasiscroto]
+- 8112: a800.xml: Removed spurious C1 control characters. [0kmg]
 - 8113: Added some TV games, and a number of educational system cartridge dumps. [Sean Riddle, David Silva, taizou, David Haywood]
 - 8115: plugins/data: Strip carriage return characters from history.xml text. [Belegdol]
-- 8116: megadriv.xml: Added seven prototypes, and replaced one monolithic dump with chip dumps. [Hidden Palace, quasiscroto]
+- 8116: megadriv.xml: Added seven prototypes, and replaced one monolithic dump with chip dumps. [Hidden Palace, 0kmg]
 - 8120: apple2gs_flop_orig.xml: Moved 16-bit software out of apple2_flop_orig.xml and added latest dumps. [4am, Firehawke]
 - 8121: sound/es5503.cpp: Register 0xE0 bits 0 and 6 should always read high. [Tim Lindner]
 - 8122: schexx4gen.cpp: Added Super Chexx (EM Bubble Hockey). [ClawGrip]
@@ -507,14 +507,14 @@ Merged pull requests
 - 8127: chexx.cpp: Add note about undumped Spanish clone. [ClawGrip]
 - 8128: merits.cpp: Added note about other machines using the same board. [ClawGrip]
 - 8129: bus/coco/coco_max.cpp: Cleaned up code a little, and fixed address mask in ff90_read. [Tim Lindner]
-- 8130: a800_flop.xml: Added five entries. [A8SP, Yoomp! Team, quasiscroto]
+- 8130: a800_flop.xml: Added five entries. [A8SP, Yoomp! Team, 0kmg]
 - 8131: pce.xml: Removed zero offsets from ROM load commands. [ClawGrip]
 - 8132: pce_tourvision.xml: Added Titan (TourVisión PCE bootleg). [Arcade Planet, ClawGrip]
 - 8133: plsonic4.cpp: Confirmed crystal value. [ClawGrip]
 - 8134: machine/6883sam.cpp: Cleaned up inconsistent spacing. [Tim Lindner]
 - 8135: bus/coco/coco_fdc.cpp: Added 5.25" double density and 3.5" double density drive options. [Tim Lindner]
 - 8136: pasha2.cpp: Removed trampolines, changed code to use bitmaps for intermediate buffers, and cleaned up code. [cam900]
-- 8137: megadriv.xml: Added twenty-one entries. [Hidden Palace, Modern Vintage Gamer, quasiscroto]
+- 8137: megadriv.xml: Added twenty-one entries. [Hidden Palace, Modern Vintage Gamer, 0kmg]
 - 8138: machine/spg2xx_io.cpp: Made SPG2xx I/O interrupt checking a bit more lean, and improved ADC behavior. [Ryan Holtz]
 - 8139: vic1001_cart.xml: Replaced bad dump of sargon2 (last byte should be RTS back to BASIC). [David Viens]
 - 8141: cclimber.cpp Added Crazy Kong (SegaSA / Sonic bootleg). [Juan Romero, ClawGrip]
@@ -529,25 +529,25 @@ Merged pull requests
 - 8151: galaxian.cpp: Moved guttangt to newer Galaxian/Scramble hardware driver, and promoted to working. [David Haywood]
 - 8153: schick.cpp: Hooked up sound chips correctly, attempted to improve graphics, and expanded notes. [David Haywood]
 - 8155: seta.cpp: Improved downtown protection simulation (fixes MT05385). [Angelo Salese]
-- 8158: nes.xml: Added three cartridges; bus/nes/action53.cpp: Improved banking emulation. [Damian Yerrick, NesDev, quasiscroto]
+- 8158: nes.xml: Added three cartridges; bus/nes/action53.cpp: Improved banking emulation. [Damian Yerrick, NesDev, 0kmg]
 - 8159: kchamp.cpp: Added Karate Champ (Tecfri bootleg). [jordigahan, ClawGrip]
 - 8160: audio/acan.cpp: Added DMA-driven sample support, and fixed sample length calculation. [Ryan Holtz, Ian Karlsson]
 - 8163: phoenix.cpp: Corrected pleiadss manufacturer. [Museo del Recreativo, ClawGrip]
 - 8164: video/galaxold.cpp: Fixed rockclim sprite bank selection. [David Haywood]
 - 8165: ibm5150.xml, ibm5170.xml, ibm5170_cdrom.xml: Added various FreeDOS versions. [Davide Cavalca]
 - 8168: galaxian.cpp: Started splitting up the driver state class to encapsulate variants. [Vas Crabb]
-- 8169: pce.xml: Removed motorod2a (appears to be a hack), and made the newer revision of R-Type Part-2 the parent. [quasiscroto]
+- 8169: pce.xml: Removed motorod2a (appears to be a hack), and made the newer revision of R-Type Part-2 the parent. [0kmg]
 - 8170: mac_hdflop.xml: Added another batch of software. [WinWorld, r09]
 - 8172: inufuku.xpp: Refactored code to meet current standards. [cam900]
 - 8173: segas16a.cpp: Changed quartet button assignments to better match the control panel. [Steven Coomber]
 - 8174: cirsa910510.cpp: Added two additional Mini Money sets. [Juan Romero, ClawGrip]
-- 8176: nes.xml: Add a dozen more prototypes from various sources. [quasiscroto]
+- 8176: nes.xml: Add a dozen more prototypes from various sources. [0kmg]
 - 8177: psikyosh.cpp: Added notes, documented ROM locations/usage, and marked cocktail mode as unsupported. [cam900]
 - 8178: osd/eminline.h: Added helpers for 64-bit count leading zeroes/ones. [Vas Crabb]
 - 8179: fmtowns_cd.xml: Added twelve entries, replaced nine entries with better dumps, and added four missing floppies. [r09]
 - 8181: video/hd61830.cpp: Fixed character blink mode. [jaens]
 - 8182: galaxian_rockclim.cpp: Reworked rockclim driver to be based on the newer galaxian.cpp driver. [David Haywood]
-- 8183: snes.xml: Added eleven prototypes. [Hidden Palace, togemet2, quasiscroto]
+- 8183: snes.xml: Added eleven prototypes. [Hidden Palace, togemet2, 0kmg]
 - 8184: mc10.cpp: Added converted expansions to slot devices. [Tim Lindner]
 - 8185: ibm5170_hdd.xml: Added a software list for pre-installed operating system images. [Davide Cavalca]
 - 8187: ibm5150.xml: Added six items, and replaced one item with a better dump. [The Good Old Days, OldGames.sk, ArcadeShadow]
@@ -571,12 +571,12 @@ Merged pull requests
 - 8215: tool/imgtool: Removed object pool usage. [Aaron Giles]
 - 8216: formats/flopimg.cpp: Removed object pool usage. [Aaron Giles]
 - 8217: leapfrog_zippity_cart.xml: Moved games’ serial numbers to their own info elements. [ClawGrip]
-- 8218: megadriv.xml: Added seven prototypes, and added ROM locations for crydragn. [quasiscroto]
+- 8218: megadriv.xml: Added seven prototypes, and added ROM locations for crydragn. [0kmg]
 - 8219: fmtowns_flop_clcracked.xml, fmtowns_flop_misc.xml, fmtowns_flop_misc.xml: Added three dumps, and updated metadata. [r09]
 - 8223: video/gime.cpp: Derive timer duration from clock frequency – fixes PAL timings. [Tim Lindner]
 - 8225: nes.xml: Added three homebrew items; bus/nes: Added support for SEALIE RET-CUFROM and partial support for SEALIE UNROM 512.
-  [quasiscroto]
-- 8226: gamegear.xml: Added two Ecco the Dolphin prototypes. [drx, quasiscroto]
+  [0kmg]
+- 8226: gamegear.xml: Added two Ecco the Dolphin prototypes. [drx, 0kmg]
 - 8227: merits.cpp: Added Scorpion (Mar 24, 1992). [jordigahan, ClawGrip]
 - 8229: x68k_flop.xml: Added two items for original floppy dumps, and explicitly marked some items as cracks. [r09, cyo.the0.vile]
 
@@ -1074,7 +1074,6 @@ World of Illusion Starring Mickey Mouse and Donald Duck (prototype) [Hidden Pala
 -match vertical spacing [0kmg]
 
 -some protos have region locks [0kmg]
- * Co-authored-by: 0kmg <0kmg@users.noreply.github.com>
 
 -fix style. fix mask. (#8129) [tim lindner]
  * CoCo MAX fixes
@@ -2182,7 +2181,6 @@ Action 53 Vol. 3 - Revenge of the Twins [Damian Yerrick, NESDev]
  * on start up point prg to correct final bank based on cart size
  * allow full 9-bit bank select per the spec
  * switch to shorter type names, u8 etc
-   - Co-authored-by: 0kmg <0kmg@users.noreply.github.com>
 
 -megadriv.xml: more protos, even more blast processing (#8137) [0kmg]
  * megadriv.xml: more protos, even more blast processing
@@ -2195,7 +2193,6 @@ Action 53 Vol. 3 - Revenge of the Twins [Damian Yerrick, NESDev]
       USA, v1.1 alt) [Hidden Palace] Psycho Pinball (prototype) [Hidden Palace] Putty Squad (early prototype) [Hidden Palace]
       Radical Rex (Euro, prototype) [Hidden Palace] Spirou (Euro, prototype) [Hidden Palace] Street Racer (Euro, prototype 19950321)
       [Hidden Palace] Tintin au Tibet (Euro, prototype) [Hidden Palace] Flux (Euro, prototype 19950425) [Hidden Palace]
-   - Co-authored-by: 0kmg <0kmg@users.noreply.github.com>
 
 -mbee: make floppy sw-items show up by default. Fixed compatibility for mbeepp. [Robbbert]
 
@@ -2632,7 +2629,6 @@ Wayne Gretzky and the NHLPA All-Stars (prototype 19950217) [Sonik]
  * fix PCB refdes errors on crydragn
  * move ggroundp and legobatm out of fully documented section
  * minor touch ups
-   - Co-authored-by: 0kmg <0kmg@users.noreply.github.com>
 
 -vis: fix card comms and crc [cracyc]
 
@@ -2737,8 +2733,6 @@ New not working software list additions
 T-34: The Battle [A8SP]
 Yoomp! [Yoomp Team]
 
--Co-authored-by: 0kmg <0kmg@users.noreply.github.com> [0kmg]
-
 -New NOT_WORKING software list addition (#8132) [ClawGrip]
 
 New NOT_WORKING software list addition
@@ -2770,14 +2764,12 @@ U-four-ia - The Saga (USA, prototype) [armadylo]
 -fix mirroring/graphics I broke earlier [0kmg]
 
 -fix mirroring I also broke [0kmg]
- * Co-authored-by: 0kmg <0kmg@users.noreply.github.com>
 
 -snes.xml: add 11 prototypes (#8183) [0kmg]
  * initial pass of 9 documented protos
  * add Atmosfear and Earthbound protos
  * fix copy/paste error
  * fix another copy/paste error
-   - Co-authored-by: 0kmg <0kmg@users.noreply.github.com>
 
 -add mapper 29 and preliminary mapper 30 support (#8225) [0kmg]
 
@@ -2923,7 +2915,6 @@ The Queen of Duellist (HME-166) [crazyc]
  * remove motorod2a which appears to be a 1-byte hack: it changes the 5-player input loop counter to not read input from players 3
     to 5
  * ok really sync + fix publisher Masaya spelling
-   - Co-authored-by: 0kmg <0kmg@users.noreply.github.com>
 
 -apple2gs: fix some 3200 viewers that check the mouse button at $C024. [R. Belmont]
 

--- a/whatsnew/whatsnew_0233.txt
+++ b/whatsnew/whatsnew_0233.txt
@@ -1057,7 +1057,6 @@ PSR-70 PortaSound [R. Belmont, Aaron Giles]
 -merits.cpp; Add note [ClawGrip]
 
 -megadriv.xml: add protos for more blast processing (#8116) [0kmg]
- * megadriv.xml: add protos for more blast processing
 
 New working software list additions
 -----------------------------------
@@ -1070,10 +1069,6 @@ Street Fighter II' - Champion Edition (prototype 19930730) [Hidden Palace]
 World of Illusion Starring Mickey Mouse and Donald Duck (prototype) [Hidden Palace]
 
 -also replace Star Wars proto dump with proper EPROM dumps [0kmg]
-
--match vertical spacing [0kmg]
-
--some protos have region locks [0kmg]
 
 -fix style. fix mask. (#8129) [tim lindner]
  * CoCo MAX fixes
@@ -2183,16 +2178,29 @@ Action 53 Vol. 3 - Revenge of the Twins [Damian Yerrick, NESDev]
  * switch to shorter type names, u8 etc
 
 -megadriv.xml: more protos, even more blast processing (#8137) [0kmg]
- * megadriv.xml: more protos, even more blast processing
-   - Bio Hazard Battle (prototype) [Modern Vintage Gamer] Ship (visitor prototype) [Modern Vintage Gamer] Disney's Aladdin
-      (prototype 19930627) [Hidden Palace] Australian Rugby League (prototype) [Hidden Palace] Captain Lang (prototype) [Hidden
-      Palace] Champions World Class Soccer (prototype) [Hidden Palace] College Football USA 96 (prototype 19950621) [Hidden Palace]
-      Danny Sullivan's Indy Heat (prototype) (pirate) [Hidden Palace] Dr. Robotnik's Mean Bean Machine (USA, prototype b) [Hidden
-      Palace] Dune - The Battle for Arrakis (Euro, prototype 19940111) [Hidden Palace] The Flintstones (Ocean prototype) [Hidden
-      Palace] Granada (Jpn, USA, v1.1 prototype) [Hidden Palace] NBA Jam (Apr 1993 prototype) [Hidden Palace] NHLPA Hockey 93 (Euro,
-      USA, v1.1 alt) [Hidden Palace] Psycho Pinball (prototype) [Hidden Palace] Putty Squad (early prototype) [Hidden Palace]
-      Radical Rex (Euro, prototype) [Hidden Palace] Spirou (Euro, prototype) [Hidden Palace] Street Racer (Euro, prototype 19950321)
-      [Hidden Palace] Tintin au Tibet (Euro, prototype) [Hidden Palace] Flux (Euro, prototype 19950425) [Hidden Palace]
+New working software list additions
+-----------------------------------
+Bio Hazard Battle (prototype) [Modern Vintage Gamer]
+Ship (visitor prototype) [Modern Vintage Gamer]
+Disney's Aladdin (prototype 19930627) [Hidden Palace]
+Australian Rugby League (prototype) [Hidden Palace]
+Captain Lang (prototype) [Hidden Palace]
+Champions World Class Soccer (prototype) [Hidden Palace]
+College Football USA 96 (prototype 19950621) [Hidden Palace]
+Danny Sullivan's Indy Heat (prototype) (pirate) [Hidden Palace]
+Dr. Robotnik's Mean Bean Machine (USA, prototype b) [Hidden Palace]
+Dune - The Battle for Arrakis (Euro, prototype 19940111) [Hidden Palace]
+The Flintstones (Ocean prototype) [Hidden Palace]
+Granada (Jpn, USA, v1.1 prototype) [Hidden Palace]
+NBA Jam (Apr 1993 prototype) [Hidden Palace]
+NHLPA Hockey 93 (Euro, USA, v1.1 alt) [Hidden Palace]
+Psycho Pinball (prototype) [Hidden Palace]
+Putty Squad (early prototype) [Hidden Palace]
+Radical Rex (Euro, prototype) [Hidden Palace]
+Spirou (Euro, prototype) [Hidden Palace]
+Street Racer (Euro, prototype 19950321) [Hidden Palace]
+Tintin au Tibet (Euro, prototype) [Hidden Palace]
+Flux (Euro, prototype 19950425) [Hidden Palace]
 
 -mbee: make floppy sw-items show up by default. Fixed compatibility for mbeepp. [Robbbert]
 
@@ -2613,7 +2621,6 @@ Hohner ADAM Advanced Digital/Analog Musical Instrument [DBWBP]
 -formats/flopimg.cpp: Remove legacy pool allocator usage. (#8216) [Aaron Giles]
 
 -megadriv.xml: add protos + some fixes (#8218) [0kmg]
- * megadriv.xml: add protos + some fixes
 
 New working software list additions
 -----------------------------------
@@ -2744,7 +2751,6 @@ pce_tourvision.xml:   Titan [Arcade Planet]
 -tourvis.cpp: Move "Tourvision" to "TourVisión" [ClawGrip]
 
 -nes.xml: add a dozen more protos (#8176) [0kmg]
- * nes.xml: add a dozen more protos
 
 New working software list additions
 -----------------------------------


### PR DESCRIPTION
Vas, I hope this helps. The main thing: I restored a barfed megadrive commit message to its original state. I also changed some places where my old username was popping up (because it's my email handle?). Lastly I removed some co-authored-by me messages. I think I fixed the cause so it shouldn't be auto-generated on future stuff of mine that gets merged. Thanks!